### PR TITLE
Fix verbose rendering in `evaluate_quality`

### DIFF
--- a/tutorials/real_vs_synthetic_vs_fake_data/Real_vs_Synthetic_vs_Fake_Data.ipynb
+++ b/tutorials/real_vs_synthetic_vs_fake_data/Real_vs_Synthetic_vs_Fake_Data.ipynb
@@ -1633,7 +1633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 49,
    "id": "7d01ef49",
    "metadata": {
     "execution": {
@@ -1643,31 +1643,15 @@
      "shell.execute_reply": "2026-04-01T12:23:19.878055Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating report ...\n",
-      "\n",
-      "(1/2) Evaluating Column Shapes: |██████████| 15/15 [00:20<00:00,  1.36s/it]|\n",
-      "Column Shapes Score: 49.39%\n",
-      "\n",
-      "(2/2) Evaluating Column Pair Trends: |██████████| 105/105 [00:08<00:00, 11.90it/s]|\n",
-      "Column Pair Trends Score: 8.93%\n",
-      "\n",
-      "Overall Score (Average): 29.16%\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sdv.evaluation.single_table import evaluate_quality\n",
     "\n",
     "fake_quality_report = evaluate_quality(\n",
     "    real_data=real_data,\n",
     "    synthetic_data=fake_data,\n",
-    "    metadata=metadata\n",
+    "    metadata=metadata,\n",
+    "    verbose=False\n",
     ")"
    ]
   },
@@ -1689,7 +1673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 51,
    "id": "6ea6a947",
    "metadata": {
     "execution": {
@@ -1699,29 +1683,13 @@
      "shell.execute_reply": "2026-04-01T12:23:25.825590Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generating report ...\n",
-      "\n",
-      "(1/2) Evaluating Column Shapes: |██████████| 15/15 [00:19<00:00,  1.30s/it]|\n",
-      "Column Shapes Score: 96.67%\n",
-      "\n",
-      "(2/2) Evaluating Column Pair Trends: |██████████| 105/105 [00:07<00:00, 13.34it/s]|\n",
-      "Column Pair Trends Score: 45.37%\n",
-      "\n",
-      "Overall Score (Average): 71.02%\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "synthetic_quality_report = evaluate_quality(\n",
     "    real_data=real_data,\n",
     "    synthetic_data=synthetic_data,\n",
-    "    metadata=metadata\n",
+    "    metadata=metadata,\n",
+    "    verbose=False\n",
     ")"
    ]
   },

--- a/tutorials/real_vs_synthetic_vs_fake_data/Real_vs_Synthetic_vs_Fake_Data.ipynb
+++ b/tutorials/real_vs_synthetic_vs_fake_data/Real_vs_Synthetic_vs_Fake_Data.ipynb
@@ -1633,7 +1633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 56,
    "id": "7d01ef49",
    "metadata": {
     "execution": {
@@ -1643,7 +1643,15 @@
      "shell.execute_reply": "2026-04-01T12:23:19.878055Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overall Score (Average): 29.40%\n"
+     ]
+    }
+   ],
    "source": [
     "from sdv.evaluation.single_table import evaluate_quality\n",
     "\n",
@@ -1652,7 +1660,9 @@
     "    synthetic_data=fake_data,\n",
     "    metadata=metadata,\n",
     "    verbose=False\n",
-    ")"
+    ")\n",
+    "\n",
+    "print(f\"Overall Score (Average): {float(fake_quality_report.get_score()):.2%}\")"
    ]
   },
   {
@@ -1673,7 +1683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 57,
    "id": "6ea6a947",
    "metadata": {
     "execution": {
@@ -1683,14 +1693,24 @@
      "shell.execute_reply": "2026-04-01T12:23:25.825590Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overall Score (Average): 71.49%\n"
+     ]
+    }
+   ],
    "source": [
     "synthetic_quality_report = evaluate_quality(\n",
     "    real_data=real_data,\n",
     "    synthetic_data=synthetic_data,\n",
     "    metadata=metadata,\n",
     "    verbose=False\n",
-    ")"
+    ")\n",
+    "\n",
+    "print(f\"Overall Score (Average): {float(synthetic_quality_report.get_score()):.2%}\")"
    ]
   },
   {


### PR DESCRIPTION
Verbose rendering is defaulted to True in evaluate_quality call. This causes the html to render with the progress bar.
